### PR TITLE
fix: spri빌드시 발생하는grty 관련 warning message 제거

### DIFF
--- a/src/main/java/com/example/skptemp/global/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/example/skptemp/global/configuration/SecurityConfiguration.java
@@ -1,20 +1,13 @@
 package com.example.skptemp.global.configuration;
 
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @RequiredArgsConstructor
@@ -26,15 +19,16 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf().disable()
-                .cors().disable()
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(request ->
                         request.dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
                                 .requestMatchers(permittedPatterns).permitAll()
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtFilter(jwtProvider), BasicAuthenticationFilter.class)
-                .formLogin().disable();
+                .formLogin(AbstractHttpConfigurer::disable);
+
         return http.build();
     }
 }


### PR DESCRIPTION
- csrf().disable, cors().disable -> spring boot 3.1 이후부터 deprecated 되어 제거