### PR TITLE
Fix[#21] : jwt 반환 body에서도 하도록 수정

### DIFF
--- a/src/main/java/com/example/skptemp/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/skptemp/domain/user/controller/UserController.java
@@ -27,10 +27,10 @@ public class UserController {
     @Operation(summary = "doLogin", description = "Login 작업을 수행합니다.")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> doLogin(HttpServletResponse response, LoginType loginType, String authProviderId){
-        LoginResponse loginResponse = userService.doLogin(loginType, authProviderId);
         User findUser = userService.findByLoginTypeAndAuthProviderId(loginType, authProviderId);
 
         String jwt = userService.createJwt(findUser.getId());
+        LoginResponse loginResponse = userService.doLogin(loginType, authProviderId, jwt);
         response.addHeader("authorization", jwt);
 
         return ResponseEntity.ok()

--- a/src/main/java/com/example/skptemp/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/example/skptemp/domain/user/dto/LoginResponse.java
@@ -2,5 +2,5 @@ package com.example.skptemp.domain.user.dto;
 
 import com.example.skptemp.global.constant.LoginType;
 
-public record LoginResponse(LoginType loginType, String authProviderId) {
+public record LoginResponse(LoginType loginType, String authProviderId, String jwt) {
 }

--- a/src/main/java/com/example/skptemp/domain/user/dto/SignUpResponse.java
+++ b/src/main/java/com/example/skptemp/domain/user/dto/SignUpResponse.java
@@ -2,5 +2,5 @@ package com.example.skptemp.domain.user.dto;
 
 import com.example.skptemp.global.constant.LoginType;
 
-public record SignUpResponse(LoginType loginType, String authProviderId) {
+public record SignUpResponse(LoginType loginType, String authProviderId, String jwt) {
 }

--- a/src/main/java/com/example/skptemp/domain/user/service/UserService.java
+++ b/src/main/java/com/example/skptemp/domain/user/service/UserService.java
@@ -5,7 +5,7 @@ import com.example.skptemp.domain.user.entity.User;
 import com.example.skptemp.global.constant.LoginType;
 
 public interface UserService {
-    LoginResponse doLogin(LoginType loginType, String authProviderId);
+    LoginResponse doLogin(LoginType loginType, String authProviderId, String jwt);
     SignUpResponse doSignup(LoginType loginType, String authProviderId);
     UserResponse findById(Long id);
     User findByLoginTypeAndAuthProviderId(LoginType loginType, String authProviderId);

--- a/src/main/java/com/example/skptemp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/skptemp/domain/user/service/UserServiceImpl.java
@@ -27,7 +27,7 @@ public class UserServiceImpl implements UserService{
 
     //TODO: login, signup 연동 플랫폼 상관 없도록 구현 변경해야
     @Override
-    public LoginResponse doLogin(LoginType loginType, String authProviderId) {
+    public LoginResponse doLogin(LoginType loginType, String authProviderId, String jwt) {
 //        SocialAuthResponse authResponse = loginService.getAccessToken(token);
 //        log.info("service auth response token: {}", authResponse.getAccessToken());
 //        SocialUserResult userResult = loginService.getUserInfo(authResponse.getAccessToken());
@@ -41,7 +41,7 @@ public class UserServiceImpl implements UserService{
         Optional<User> findUser = userRepository.findByLoginTypeAndAuthProviderId(loginType, authProviderId);
         findUser.orElseThrow(() -> new GlobalException("존재 하지 않는 사용자 입니다.", GlobalErrorCode.USER_VALID_EXCEPTION));
 
-        return new LoginResponse(loginType, authProviderId);
+        return new LoginResponse(loginType, authProviderId, jwt);
     }
     @Transactional
     @Override
@@ -54,7 +54,10 @@ public class UserServiceImpl implements UserService{
         assertDuplicateUser(loginType, authProviderId);
         userRepository.save(user);
 
-        return new SignUpResponse(loginType, authProviderId);
+        User findUser = findByLoginTypeAndAuthProviderId(loginType, authProviderId);
+        String jwt = createJwt(findUser.getId());
+
+        return new SignUpResponse(loginType, authProviderId, jwt);
     }
 
     @Override

--- a/src/test/java/com/example/skptemp/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/example/skptemp/domain/user/service/UserServiceImplTest.java
@@ -66,7 +66,7 @@ class UserServiceImplTest {
         SignUpResponse signUpResponse = userService.doSignup(LoginType.APPLE, TEST_AUTH_PROVIDER_ID_APPLE);
 
         //when
-        LoginResponse loginResponse = userService.doLogin(LoginType.APPLE, TEST_AUTH_PROVIDER_ID_APPLE);
+        LoginResponse loginResponse = userService.doLogin(LoginType.APPLE, TEST_AUTH_PROVIDER_ID_APPLE, userService.createJwt(USER_ID));
         //then
         assertThat(loginResponse.loginType()).isEqualTo(LoginType.APPLE);
         assertThat(loginResponse.authProviderId()).isEqualTo(TEST_AUTH_PROVIDER_ID_APPLE);


### PR DESCRIPTION
### Issues: 
#21 

### Motivation 
- 현재 iOS 네트워크 로직 구현 상 헤더보다 바디에서 값을 처리하는 것이 더 용이

### Key Change
- 회원 가입 및 로그인 api에서 jwt를 바디에서도 반환하도록 수정
- 8fcb6b77bf58dfb3df0bb7ea85edba82bc6b3881

<img width="500" alt="image" src="https://github.com/team-bukki/buki-backend/assets/63584245/6e21542e-fdd2-4974-96d8-3af2c3eb637b">
<img width="500" alt="image" src="https://github.com/team-bukki/buki-backend/assets/63584245/6140be30-0600-44ea-84ef-bfe8a43c4b6f">


### To Reviwer
@rkdehdgns1230 @suker80 

현재 부키 BE 컨벤션을 몰라 익숙한대로 작성하였는데, 수정할 부분을 말씀해주시면 바로 수정하겠습니다.