### PR TITLE
Feature/user - 계정 삭제 API 추가, jwt 발급 과정 개선, jwt key 변경

### DIFF
--- a/src/main/java/com/example/skptemp/domain/user/entity/User.java
+++ b/src/main/java/com/example/skptemp/domain/user/entity/User.java
@@ -31,26 +31,21 @@ public class User extends BaseEntity {
 
     protected User(){
     }
-    private User(String uuid, LoginType loginType, String platformProviderId, String authority){
-        this.code = uuid;
-        this.loginType = loginType;
-        this.platformProviderId = platformProviderId;
-        this.authority = authority;
-        this.isValid = true;
-    }
 
-    private User(String uuid, LoginType loginType, String platformProviderId, String authority, String pushToken){
+    private User(String uuid, LoginType loginType, String platformProviderId, String firstName, String lastName, String authority, String pushToken){
         this.code = uuid;
         this.loginType = loginType;
         this.platformProviderId = platformProviderId;
+        this.firstName = firstName;
+        this.lastName = lastName;
         this.authority = authority;
         this.pushToken = pushToken;
         this.isValid = true;
     }
 
-    public static User createUser(LoginType loginType, String authProviderId, String firstName, String lastName, String pushToken){
+    public static User createUser(LoginType loginType, String platformProviderId, String firstName, String lastName, String pushToken){
         String uuid = makeUuid(false);
-        return new User(uuid, loginType, authProviderId, "USER", pushToken);
+        return new User(uuid, loginType, platformProviderId, firstName, lastName, "USER", pushToken);
     }
 
     public void deleteUser(){

--- a/src/main/java/com/example/skptemp/domain/user/service/UserService.java
+++ b/src/main/java/com/example/skptemp/domain/user/service/UserService.java
@@ -11,6 +11,8 @@ public interface UserService {
     User findByLoginTypeAndAuthProviderId(LoginType loginType, String authProviderId);
     User findByCode(String code);
     String createJwt(Long id);
+    String createTestJwt();
     UserResponse changeUserName(UserChangeNameRequest request);
     void deleteUser(Long id);
+    void validateUserOrThrow(Long id);
 }

--- a/src/main/java/com/example/skptemp/global/configuration/JwtFilter.java
+++ b/src/main/java/com/example/skptemp/global/configuration/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.example.skptemp.global.configuration;
 
+import com.example.skptemp.domain.user.service.UserService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,6 +19,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
+    private final UserService userService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -37,11 +39,12 @@ public class JwtFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
             return;
         }
-        String userId = jwtProvider.getUserId(token);
+        Long userId = jwtProvider.getUserId(token);
+        userService.validateUserOrThrow(userId);
+
         Authentication authentication = jwtProvider.getAuthentication(token);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);
     }
-
 }

--- a/src/main/java/com/example/skptemp/global/configuration/JwtProvider.java
+++ b/src/main/java/com/example/skptemp/global/configuration/JwtProvider.java
@@ -1,13 +1,10 @@
 package com.example.skptemp.global.configuration;
 
 import com.example.skptemp.global.util.GlobalConstants;
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -26,7 +23,6 @@ import java.util.Date;
 public class JwtProvider {
 
     private final SecretKey secretKey;
-    private static final String userIdKey = "userId";
     private final UserDetailsService userDetailsService;
 
     public JwtProvider(@Value("${jwt.password}") String secretKey, UserDetailsService userDetailsService){
@@ -55,8 +51,8 @@ public class JwtProvider {
 
         return Jwts.builder()
                 .claims()
-                .add("role", role)
-                .add("userId", userId)
+                .add(GlobalConstants.JWT_USER_ROLE, role)
+                .add(GlobalConstants.JWT_USER_ID_KEY, userId)
                 .issuedAt(now)
                 .expiration(expiration)
                 .subject(userDetails.getUsername())
@@ -72,7 +68,7 @@ public class JwtProvider {
                 .build()
                 .parseSignedClaims(token)
                 .getPayload()
-                .get(userIdKey)
+                .get(GlobalConstants.JWT_USER_ID_KEY)
                 .toString());
     }
     public Authentication getAuthentication(String token){

--- a/src/main/java/com/example/skptemp/global/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/example/skptemp/global/configuration/SecurityConfiguration.java
@@ -1,5 +1,6 @@
 package com.example.skptemp.global.configuration;
 
+import com.example.skptemp.domain.user.service.UserService;
 import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -15,7 +16,16 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 @EnableWebSecurity
 public class SecurityConfiguration {
     private final JwtProvider jwtProvider;
-    private final String[] permittedPatterns = { "/api/v1/users/login", "/api/v1/users/sign-up", "/api/v1/users/create-token", "/test", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-config" };
+    private final UserService userService;
+    private final String[] permittedPatterns = {
+            "/api/v1/users/login",
+            "/api/v1/users/sign-up",
+            "/api/v1/users/create-token-100days",
+            "/api/v1/users/create-token-10min",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/swagger-config" };
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -26,7 +36,7 @@ public class SecurityConfiguration {
                                 .requestMatchers(permittedPatterns).permitAll()
                                 .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtFilter(jwtProvider), BasicAuthenticationFilter.class)
+                .addFilterBefore(new JwtFilter(jwtProvider, userService), BasicAuthenticationFilter.class)
                 .formLogin(AbstractHttpConfigurer::disable);
 
         return http.build();

--- a/src/main/java/com/example/skptemp/global/error/GlobalErrorCode.java
+++ b/src/main/java/com/example/skptemp/global/error/GlobalErrorCode.java
@@ -13,6 +13,8 @@ public enum GlobalErrorCode {
     VALID_EXCEPTION(400, "G300", "유효 하지 않은 요청입니다."),
 
     USER_VALID_EXCEPTION(400, "G310", "유저가 유효하지 않습니다."),
+    USER_DELETED_EXCEPTION(400, "G311", "삭제된 계정입니다."),
+    TEST_ACCOUNT_INVALID(500, "G312", "테스트용 계정 오류입니다."),
 
     ITEM_VALID_EXCEPTION(400, "G320", "아이템이 유효하지 않습니다."),
     ITEM_COUNT_EXCEPTION(400, "G321", "아이템 개수가 유효하지 않습니다."),
@@ -25,7 +27,6 @@ public enum GlobalErrorCode {
     TOKEN_EXPIRED(401, "G500", "토큰이 만료되었습니다."),
 
     USER_CONFLICT(409, "G600", "이미 가입된 내역이 있습니다."),
-
 
     ;
     private final String code;

--- a/src/main/java/com/example/skptemp/global/util/GlobalConstants.java
+++ b/src/main/java/com/example/skptemp/global/util/GlobalConstants.java
@@ -4,4 +4,6 @@ public class GlobalConstants {
     public static final Long TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 100L;    // 100 days
     public static final Long TEST_TOKEN_EXPIRATION_TIME = 1000 * 60 * 10L;          // 10 minutes
     public static final Long TEST_ACCOUNT_ID = 1L;                                  // 테스트 토큰 발급용 계정 ID
+    public static final String JWT_USER_ID_KEY = "user_id";                         // jwt key user id 생성 및 조회 용도
+    public static final String JWT_USER_ROLE = "role";                              // jwt key role 생성 및 조회 용도
 }

--- a/src/main/java/com/example/skptemp/global/util/GlobalConstants.java
+++ b/src/main/java/com/example/skptemp/global/util/GlobalConstants.java
@@ -1,5 +1,7 @@
 package com.example.skptemp.global.util;
 
 public class GlobalConstants {
-    public static final Long TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 7L; // 7 days
+    public static final Long TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 100L;    // 100 days
+    public static final Long TEST_TOKEN_EXPIRATION_TIME = 1000 * 60 * 10L;          // 10 minutes
+    public static final Long TEST_ACCOUNT_ID = 1L;                                  // 테스트 토큰 발급용 계정 ID
 }

--- a/src/test/java/com/example/skptemp/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/skptemp/domain/user/service/UserServiceTest.java
@@ -3,8 +3,6 @@ package com.example.skptemp.domain.user.service;
 import com.example.skptemp.domain.user.dto.LoginResponse;
 import com.example.skptemp.domain.user.dto.SignUpResponse;
 import com.example.skptemp.domain.user.dto.SignupRequest;
-import com.example.skptemp.domain.user.dto.UserResponse;
-import com.example.skptemp.domain.user.repository.UserRepository;
 import com.example.skptemp.global.configuration.JwtProvider;
 import com.example.skptemp.global.constant.LoginType;
 import com.example.skptemp.global.error.GlobalException;
@@ -48,7 +46,7 @@ class UserServiceTest {
         //given
         String jwt = userService.createJwt(USER_ID);
         //when
-        Long userId = Long.parseLong(jwtProvider.getUserId(jwt));
+        Long userId = jwtProvider.getUserId(jwt);
         //then
         assertThat(userId).isEqualTo(USER_ID);
     }
@@ -69,7 +67,7 @@ class UserServiceTest {
     @Test
     void 로그인_성공(){
         //given
-        SignUpResponse signUpResponse = userService.doSignup(
+        userService.doSignup(
                 new SignupRequest(LoginType.APPLE, TEST_AUTH_PROVIDER_ID_APPLE, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_PUSH_TOKEN)
         );
 
@@ -81,13 +79,13 @@ class UserServiceTest {
     }
 
     @Test
-    void 사용자_삭제_for_dev_성공(){
+    void 사용자_삭제_성공(){
         //given
         SignUpResponse signUpResponse = userService.doSignup(
                 new SignupRequest(LoginType.APPLE, TEST_AUTH_PROVIDER_ID_APPLE_FOR_DEV, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_PUSH_TOKEN)
         );
         String jwt = signUpResponse.jwt();
-        Long userId = Long.parseLong(jwtProvider.getUserId(jwt));
+        Long userId = jwtProvider.getUserId(jwt);
 
         //when
         userService.deleteUser(userId);
@@ -96,4 +94,19 @@ class UserServiceTest {
         Assertions.assertThrows(GlobalException.class, () -> userService.findById(userId));
     }
 
+    @Test
+    void 사용자_삭제_중복_삭제_실패(){
+        //given
+        SignUpResponse signUpResponse = userService.doSignup(
+                new SignupRequest(LoginType.APPLE, TEST_AUTH_PROVIDER_ID_APPLE_FOR_DEV, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_PUSH_TOKEN)
+        );
+        String jwt = signUpResponse.jwt();
+        Long userId = jwtProvider.getUserId(jwt);
+
+        //when
+        userService.deleteUser(userId);
+
+        //then
+        Assertions.assertThrows(GlobalException.class, () -> userService.deleteUser(userId)); // 중복 삭제한 경우 Exception Throw
+    }
 }


### PR DESCRIPTION
- 계정 삭제 API 개발 완료 (jwt 이용, 별도 parameter 필요 없음)
    - 실제 데이터 삭제가 아닌 invalid 처리
- 2가지 방식으로 access token (jwt) 발급 가능
    - /api/v1/create-token-100days : 100일 후 만료
    - /api/v1/create-token-10min : 10분 후 만료
- jwt key 정보 변경
    - userName (string type) -> userId (long type)
#26 