### PR TITLE
Feature/profile : profile 분리 작업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,6 @@ out/
 .vscode/
 /src/main/generated/
 
-*.yml
+/src/main/resources/application-develop.yml
 
 /src/main/resources/buki-c97ff-firebase-adminsdk-qucmh-0a6cb245c5.json

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,23 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+
+logging:
+  level:
+    root: DEBUG
+
+jwt:
+  password: sdfasdfasfdaasdfsdfasdfasfdaasdfasdfasdfasdfasdf # 48 * 6 = 288

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  profiles:
+    default: local
+
+server:
+  port: 8080
+
+# swagger-ui custom path
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html


### PR DESCRIPTION
## 개요
개발 서버에서와 로컬에서 환경을 분리하기 위함
- local : h2 database (in-memory db)
- develop : mysql database
  
## 변경 사항
- application-local.yml 은 git으로 관리할 수 있다.
- application-develop.yml 은 develop profile을 사용하는 개발 서버에서만 사용한다. (몰라도 됨)
- 기존 개발자들은 firebase 관련 json 파일만 추가하여, 사용하면 되고 이제 환경에 따라 application.yml, application-local.yml 추가 작성하지 않아도 된다.

#43